### PR TITLE
chore: remove dh-systemd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends:
     cmake (>=3.1),
     debhelper (>=9),
-    dh-systemd,
     g++ (>=6.3.0),
     gettext,
     libattr1-dev,


### PR DESCRIPTION
移除 [dh-systemd](https://packages.debian.org/sid/dh-systemd) 依赖

> ### debhelper add-on to handle systemd unit files - transitional package
> This package is for transitional purposes and can be removed safely.

是处理 https://github.com/linuxdeepin/developer-center/issues/3230 问题的一部分。